### PR TITLE
Improve td3 lander

### DIFF
--- a/environment/cogment_verse_environment/base_agent_adapter.py
+++ b/environment/cogment_verse_environment/base_agent_adapter.py
@@ -44,7 +44,7 @@ class BaseAgentAdapter(AgentAdapter):
 
             config = actor_session.config
 
-            async for event in actor_session.event_loop():
+            async for event in actor_session.all_events():
                 if event.observation and event.type == cogment.EventType.ACTIVE:
                     action = np.random.default_rng().integers(0, config.environment_specs.num_action)
                     actor_session.do_action(AgentAction(discrete_action=action))

--- a/environment/cogment_verse_environment/environment_adapter.py
+++ b/environment/cogment_verse_environment/environment_adapter.py
@@ -180,7 +180,7 @@ class EnvironmentAdapter:
                 )
                 environment_session.start([("*", cog_obs)])
 
-                async for event in environment_session.event_loop():
+                async for event in environment_session.all_events():
                     if event.actions:
                         player_override = -1
                         # special handling of human intervention

--- a/tf_agents/cogment_verse_tf_agents/reinforce/reinforce_agent_adapter.py
+++ b/tf_agents/cogment_verse_tf_agents/reinforce/reinforce_agent_adapter.py
@@ -72,7 +72,7 @@ class ReinforceAgentAdapter(AgentAdapter):
 
             total_reward = 0
 
-            async for event in actor_session.event_loop():
+            async for event in actor_session.all_events():
                 for reward in event.rewards:
                     total_reward += reward.value
 

--- a/torch_agents/cogment_verse_torch_agents/hive_adapter/hive_agent_adapter.py
+++ b/torch_agents/cogment_verse_torch_agents/hive_adapter/hive_agent_adapter.py
@@ -112,7 +112,7 @@ class HiveAgentAdapter(AgentAdapter):
 
                 total_reward = 0
 
-                async for event in actor_session.event_loop():
+                async for event in actor_session.all_events():
                     for reward in event.rewards:
                         total_reward += reward.value
 

--- a/torch_agents/cogment_verse_torch_agents/muzero/adapter.py
+++ b/torch_agents/cogment_verse_torch_agents/muzero/adapter.py
@@ -204,7 +204,7 @@ class MuZeroAgentAdapter(AgentAdapter):
             worker.start()
 
             try:
-                async for event in actor_session.event_loop():
+                async for event in actor_session.all_events():
                     assert worker.is_alive()
                     if event.observation and event.type == cogment.EventType.ACTIVE:
                         await worker.put_event(event)

--- a/torch_agents/cogment_verse_torch_agents/selfplay_td3/selfplay_agent.py
+++ b/torch_agents/cogment_verse_torch_agents/selfplay_td3/selfplay_agent.py
@@ -54,7 +54,7 @@ class SelfPlayAgentAdapter(AgentAdapter):
             agent = actor_session.config.model_id.split("_")[-1]
             total_reward = 0
 
-            async for event in actor_session.event_loop():
+            async for event in actor_session.all_events():
                 for reward in event.rewards:
                     total_reward += reward.value
 

--- a/torch_agents/cogment_verse_torch_agents/simple_a2c/simple_a2c_agent.py
+++ b/torch_agents/cogment_verse_torch_agents/simple_a2c/simple_a2c_agent.py
@@ -113,7 +113,7 @@ class SimpleA2CAgentAdapter(AgentAdapter):
                 config.model_id, config.model_version, environment_specs=config.environment_specs
             )
 
-            async for event in actor_session.event_loop():
+            async for event in actor_session.all_events():
                 if event.observation and event.type == cogment.EventType.ACTIVE:
                     obs = tensor_from_cog_obs(event.observation.snapshot, dtype=self._dtype)
                     scores = model.actor_network(obs)

--- a/torch_agents/cogment_verse_torch_agents/simple_bc/dqn_agent.py
+++ b/torch_agents/cogment_verse_torch_agents/simple_bc/dqn_agent.py
@@ -124,7 +124,7 @@ class DQNAgent(AgentAdapter):
                 action = torch.distributions.Categorical(probs).sample()
                 return action
 
-            async for event in actor_session.event_loop():
+            async for event in actor_session.all_events():
                 if event.observation and event.type == cogment.EventType.ACTIVE:
                     action = await self.run_async(compute_action, event)
                     actor_session.do_action(cog_action_from_tensor(action))

--- a/torch_agents/cogment_verse_torch_agents/simple_bc/td3_agent.py
+++ b/torch_agents/cogment_verse_torch_agents/simple_bc/td3_agent.py
@@ -179,7 +179,7 @@ class TD3Agent(AgentAdapter):
                     #print('action: ', action)
                     return action
 
-            async for event in actor_session.event_loop():
+            async for event in actor_session.all_events():
                 if event.observation and event.type == cogment.EventType.ACTIVE:
                     action = await self.run_async(compute_action, event)
                     actor_session.do_action(cog_continuous_action_from_tensor(action))
@@ -282,9 +282,9 @@ class TD3Agent(AgentAdapter):
                     run_id=run_session.run_id,
                     environment=env_params,
                     #headless
-                    # actors=[agent_actor_params],
+                    actors=[agent_actor_params],
                     #not headless
-                    actors=[agent_actor_params, teacher_actor_params],
+                    #actors=[agent_actor_params, teacher_actor_params],
                 )
 
             # Keep accumulated observations/actions around

--- a/torch_agents/cogment_verse_torch_agents/simple_bc/td3_agent.py
+++ b/torch_agents/cogment_verse_torch_agents/simple_bc/td3_agent.py
@@ -392,6 +392,7 @@ class TD3Agent(AgentAdapter):
             ##########################################
 
             # Rollout a bunch of trials
+            num_trials = 0
             async for (
                 ############ TUTORIAL STEP 4 ############
                 step_idx,
@@ -419,10 +420,12 @@ class TD3Agent(AgentAdapter):
                 if done:
                     action = torch.tensor([0., 0.])
 
+                    num_trials += 1
                     xp_tracker.log_metrics(
                         step_timestamp,
                         step_idx,
                         total_reward=total_reward.item(),
+                        num_trials=num_trials
                     )
 
                 buffer.add(observation, action, reward, done)

--- a/torch_agents/cogment_verse_torch_agents/simple_bc/tutorial_1.py
+++ b/torch_agents/cogment_verse_torch_agents/simple_bc/tutorial_1.py
@@ -56,7 +56,7 @@ class SimpleBCAgentAdapterTutorialStep1(AgentAdapter):
 
             config = actor_session.config
 
-            async for event in actor_session.event_loop():
+            async for event in actor_session.all_events():
                 if event.observation and event.type == cogment.EventType.ACTIVE:
                     action = np.random.default_rng().integers(0, config.environment_specs.num_action)
                     actor_session.do_action(AgentAction(discrete_action=action))

--- a/torch_agents/cogment_verse_torch_agents/simple_bc/tutorial_2.py
+++ b/torch_agents/cogment_verse_torch_agents/simple_bc/tutorial_2.py
@@ -62,7 +62,7 @@ class SimpleBCAgentAdapterTutorialStep2(AgentAdapter):
 
             config = actor_session.config
 
-            async for event in actor_session.event_loop():
+            async for event in actor_session.all_events():
                 if event.observation and event.type == cogment.EventType.ACTIVE:
                     action = np.random.default_rng().integers(0, config.environment_specs.num_action)
                     actor_session.do_action(AgentAction(discrete_action=action))

--- a/torch_agents/cogment_verse_torch_agents/simple_bc/tutorial_3.py
+++ b/torch_agents/cogment_verse_torch_agents/simple_bc/tutorial_3.py
@@ -126,7 +126,7 @@ class SimpleBCAgentAdapterTutorialStep3(AgentAdapter):
                 action = torch.distributions.Categorical(probs).sample()
                 return action
 
-            async for event in actor_session.event_loop():
+            async for event in actor_session.all_events():
                 if event.observation and event.type == cogment.EventType.ACTIVE:
                     action = await self.run_async(compute_action, event)
                     actor_session.do_action(cog_action_from_tensor(action))

--- a/torch_agents/cogment_verse_torch_agents/simple_bc/tutorial_4.py
+++ b/torch_agents/cogment_verse_torch_agents/simple_bc/tutorial_4.py
@@ -120,7 +120,7 @@ class SimpleBCAgentAdapterTutorialStep4(AgentAdapter):
                 action = torch.distributions.Categorical(probs).sample()
                 return action
 
-            async for event in actor_session.event_loop():
+            async for event in actor_session.all_events():
                 if event.observation and event.type == cogment.EventType.ACTIVE:
                     action = await self.run_async(compute_action, event)
                     actor_session.do_action(cog_action_from_tensor(action))


### PR DESCRIPTION
- Properly track the total reward, the previous way of doing it didn't work because of the parallel executions of trials. 
    In practice the samples retrieved in the loop
    ```python
    async for (... ) in run_session.start_trials_and_wait_for_termination(...):
    ```
     are out of order (it can be any sample from any of the ongoing trials).
     
      What I've done is compute a total reward alongside the sample in the sample producer (which is run per-trial) and log it to mlflow when on a last sample of each trial
- Add tracking for the number of trials

## Other ##
- Remove the deprecated `event_loop()`